### PR TITLE
Improve docs site and README structure

### DIFF
--- a/.claude/marr/standards/prj-documentation-standard.md
+++ b/.claude/marr/standards/prj-documentation-standard.md
@@ -28,6 +28,26 @@ triggers:
 3. **Keep content types distinct** because mixed purposes confuse readers
 4. **Update docs when code changes** because outdated docs mislead users
 5. **No AI attribution** because content stands on merit, not origin
+6. **Keep release documentation current** because stale release notes and known issues erode trust
+
+---
+
+## Release Documentation
+
+The following files MUST be kept current at all times, and MUST be updated before creating any new release:
+
+| File | Purpose | Update trigger |
+|---|---|---|
+| `README.md` | Project overview and getting started | Any change to project structure, setup steps, or features |
+| `docs/README.md` | Docs site landing page | Any change to documentation structure or content |
+| `RELEASE_NOTES.md` | Cumulative changelog by version | Before every release — add the new version section |
+| `KNOWN_ISSUES.md` | Active issues and limitations | When issues are discovered, resolved, or planned for a release |
+
+**Before creating a release:**
+- [ ] `RELEASE_NOTES.md` has a section for the new version with all changes
+- [ ] `KNOWN_ISSUES.md` reflects current state — new issues added, resolved issues noted
+- [ ] `README.md` releases table includes the new version
+- [ ] `docs/README.md` release references are current
 
 ---
 
@@ -100,3 +120,4 @@ Diagrams MUST stay consistent with the surrounding documentation. Update diagram
 - **Mixing content types** — How-to guides with theory, reference that teaches, explanations with procedures
 - **Leaving stale docs** — Update or remove, never ignore
 - **Creating redundant docs** — One authoritative source per topic
+- **Releasing without updating release docs** — RELEASE_NOTES.md, KNOWN_ISSUES.md, and READMEs must be current before any release

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -1,0 +1,36 @@
+# Known Issues
+
+> **Note:** Many issues in earlier releases (v1.0.0–v2.0.0) are deliberate simplifications to keep the implementation accessible for learning. They will be addressed progressively in later releases as complexity is layered in.
+
+## v3.2.0 (upcoming)
+
+### Documentation site not responsive to device display sizes
+
+The Docsify-based docs site does not adapt to mobile or tablet viewports. The sidebar, header, and content layout assume a desktop-width display. On smaller screens the sidebar overlaps content and the header tabs may be clipped.
+
+**Workaround:** View the docs on a desktop browser or zoom out on mobile.
+
+### v3.x demo is overly complicated
+
+The PowerSync demo (`powersync-demo/`) includes deletion and sync status indicators. While these features demonstrate real-world patterns, they complicate both the implementation and the learning experience for someone following the progressive tutorial path.
+
+**Plan:** Simplify the v3.x demo to focus on the core offline-first concept — local reads and writes that sync when connectivity returns. Deletion, status indicators, and other features will be progressively added in subsequent releases.
+
+## v3.1.0
+
+No new issues introduced. All v3.0.0 issues remain open.
+
+## v3.0.0
+
+- PowerSync demo requires Vite build step (WASM + web workers), adding complexity vs the plain HTML demos
+- Conflict resolution not yet implemented — concurrent edits from different clients create duplicate rows rather than merging
+
+## v2.0.0
+
+- Supabase Realtime requires manual publication setup (`alter publication supabase_realtime add table`)
+- No offline fallback — if the WebSocket disconnects, the UI does not indicate loss of sync
+
+## v1.0.0
+
+- No error handling for failed Supabase requests
+- Credentials hardcoded in HTML files (suitable for learning, not production)

--- a/README.md
+++ b/README.md
@@ -125,6 +125,21 @@ The `.mcp.json` and `.claude/settings.json` files are checked in — Claude Code
 
 ---
 
+## Releases
+
+Each release marks a working milestone in the progression from online-first to offline-first. You can check out any tag to see the project at that stage.
+
+| Release | What it adds |
+|---|---|
+| [v1.0.0](https://github.com/virtualian/offline-first/releases/tag/v1.0.0) | Initial online-first example app — direct reads and writes to Supabase |
+| [v2.0.0](https://github.com/virtualian/offline-first/releases/tag/v2.0.0) | Online sync with Supabase Realtime — multi-client WebSocket sync |
+| [v3.0.0](https://github.com/virtualian/offline-first/releases/tag/v3.0.0) | Offline-first with PowerSync — local SQLite with bidirectional sync |
+| [v3.1.0](https://github.com/virtualian/offline-first/releases/tag/v3.1.0) | Diataxis documentation site |
+
+See all [releases](https://github.com/virtualian/offline-first/releases) | [release notes](RELEASE_NOTES.md) | [known issues](KNOWN_ISSUES.md).
+
+---
+
 ## Discussions
 
 Questions, ideas, or feedback? Join the [discussions](https://github.com/virtualian/offline-first/discussions).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,51 @@
+# Release Notes
+
+## v3.2.0 (upcoming)
+
+### Improved documentation site and simplified demo
+
+- Documentation site header with title, home button, and role-based navigation tabs
+- Collapsible sidebar sections with intro pages for each role and content type
+- Landing page rewritten as a getting-started guide
+- README restructured: clone and docs are now the first steps
+- Known issues documented and tracked
+
+**Planned:**
+- Simplify the PowerSync demo to focus on core offline-first sync
+- Remove deletion and status indicators to reduce implementation complexity
+- Progressively re-add features in subsequent releases
+
+## v3.1.0 — Diataxis Documentation Site
+
+Released: 2026-03-29
+
+- Restructured documentation into a Diataxis site with three audience roles (Developer, Maintainer, Contributor) and four content types (Tutorials, How-To, Reference, Explanation)
+- Docsify-powered docs site with search, Mermaid diagrams, and syntax highlighting
+- Tutorials walk through the full online-first to offline-first progression
+- How-to guides for setting up each demo independently
+
+## v3.0.0 — Offline-First with PowerSync
+
+Released: 2026-03-29
+
+- Offline-first demo using PowerSync for local-first sync with Supabase
+- Local SQLite database via WASM with bidirectional cloud sync
+- Notes persist offline and sync automatically when connectivity returns
+- Sync status indicators show per-note sync state
+- Vite build tooling for WASM and web worker support
+
+## v2.0.0 — Online Sync with Supabase Realtime
+
+Released: 2026-03-27
+
+- Online sync demo using Supabase Realtime WebSocket channels
+- Multiple browser tabs and windows see changes instantly
+- Notes added or deleted in any instance appear or disappear across all connected clients
+
+## v1.0.0 — Initial Online-First Example App
+
+Released: 2026-03-27
+
+- Plain HTML + Supabase JS app that reads and writes directly to Postgres
+- No framework, no build step — single HTML file
+- Demonstrates the simplest possible online-first architecture

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,8 @@
 
 This project starts from the simplest possible online-first baseline and progressively adds offline capabilities, one step at a time. Each step has a working demo and documentation explaining the concepts behind it.
 
+Each [release](https://github.com/virtualian/offline-first/releases) marks a working milestone — from online-first ([v1.0.0](https://github.com/virtualian/offline-first/releases/tag/v1.0.0)) through realtime sync ([v2.0.0](https://github.com/virtualian/offline-first/releases/tag/v2.0.0)) to offline-first ([v3.0.0](https://github.com/virtualian/offline-first/releases/tag/v3.0.0)). Check out any tag to see the project at that stage. See the [release notes](https://github.com/virtualian/offline-first/blob/main/RELEASE_NOTES.md) and [known issues](https://github.com/virtualian/offline-first/blob/main/KNOWN_ISSUES.md).
+
 **Questions or feedback?** Join the [discussions](https://github.com/virtualian/offline-first/discussions).
 
 ## What you'll learn

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,31 +1,30 @@
-- **Developer**
-  - Tutorials
+- [Home](/)
+- [Developer](developers/)
+  - [Tutorials](developers/tutorials/)
     - [Build a Notes App with Supabase](developers/tutorials/online-first.md)
     - [Add Realtime Sync](developers/tutorials/online-with-sync.md)
     - [Make It Work Offline](developers/tutorials/offline-first.md)
-  - How-To
+  - [How-To](developers/how-to/)
     - [Set Up the Online-First Demo](developers/how-to/setup-online-first.md)
     - [Set Up the Online Sync Demo](developers/how-to/setup-online-sync.md)
     - [Set Up the PowerSync Demo](developers/how-to/setup-offline-first.md)
-  - Reference
+  - [Reference](developers/reference/)
     - [Architecture](developers/reference/architecture.md)
     - [Supabase Configuration](developers/reference/supabase-config.md)
     - [PowerSync Configuration](developers/reference/powersync-config.md)
-  - Explanation
+  - [Explanation](developers/explanation/)
     - [Why Online-First Works](developers/explanation/online-first.md)
     - [How Realtime Sync Works](developers/explanation/realtime-sync.md)
     - [How Offline-First Works](developers/explanation/offline-first.md)
-
-- **Maintainer**
-  - How-To
+- [Maintainer](maintainers/)
+  - [How-To](maintainers/how-to/)
     - [Run All Demos](maintainers/how-to/run-demos.md)
-  - Reference
+  - [Reference](maintainers/reference/)
     - [Infrastructure](maintainers/reference/infrastructure.md)
-  - Explanation
+  - [Explanation](maintainers/explanation/)
     - [Architecture Decisions](maintainers/explanation/architecture-decisions.md)
-
-- **Contributor**
-  - How-To
+- [Contributor](contributors/)
+  - [How-To](contributors/how-to/)
     - [How to Contribute](contributors/how-to/contributing.md)
-  - Reference
+  - [Reference](contributors/reference/)
     - [Project Structure](contributors/reference/project-structure.md)

--- a/docs/contributors/README.md
+++ b/docs/contributors/README.md
@@ -1,0 +1,10 @@
+# Contributor Docs
+
+> For anyone submitting changes to this project.
+
+These docs cover how to contribute and how the project is structured.
+
+## Sections
+
+- [How-To](contributors/how-to/) — contributing workflow and guidelines
+- [Reference](contributors/reference/) — project structure and conventions

--- a/docs/contributors/how-to/README.md
+++ b/docs/contributors/how-to/README.md
@@ -1,0 +1,5 @@
+# How-To Guides
+
+> Contributing workflow and guidelines.
+
+- [How to Contribute](contributors/how-to/contributing.md) — branching, commits, and pull request process

--- a/docs/contributors/reference/README.md
+++ b/docs/contributors/reference/README.md
@@ -1,0 +1,5 @@
+# Reference
+
+> Project structure and conventions.
+
+- [Project Structure](contributors/reference/project-structure.md) — directory layout and file responsibilities

--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -1,0 +1,12 @@
+# Developer Docs
+
+> For anyone building with or learning from this project.
+
+These docs cover everything from first setup to deep dives into how the sync layers work.
+
+## Where to start
+
+- **New here?** Work through the [Tutorials](developers/tutorials/) in order — they build on each other
+- **Setting up a specific demo?** Jump to the [How-To guides](developers/how-to/)
+- **Looking something up?** Check the [Reference](developers/reference/) docs
+- **Want to understand why things work this way?** Read the [Explanations](developers/explanation/)

--- a/docs/developers/explanation/README.md
+++ b/docs/developers/explanation/README.md
@@ -1,0 +1,7 @@
+# Explanation
+
+> The "why" behind design decisions and trade-offs.
+
+- [Why Online-First Works](developers/explanation/online-first.md) — the simplest architecture and when it's enough
+- [How Realtime Sync Works](developers/explanation/realtime-sync.md) — WebSocket change streaming and its limitations
+- [How Offline-First Works](developers/explanation/offline-first.md) — local-first with bidirectional sync via PowerSync

--- a/docs/developers/how-to/README.md
+++ b/docs/developers/how-to/README.md
@@ -1,0 +1,9 @@
+# How-To Guides
+
+> Focused steps for a specific task. These assume you already understand the basics.
+
+Pick the demo you want to run:
+
+- [Set Up the Online-First Demo](developers/how-to/setup-online-first.md) — direct reads and writes to Supabase
+- [Set Up the Online Sync Demo](developers/how-to/setup-online-sync.md) — Supabase Realtime across tabs and browsers
+- [Set Up the PowerSync Demo](developers/how-to/setup-offline-first.md) — offline-capable app with local SQLite

--- a/docs/developers/reference/README.md
+++ b/docs/developers/reference/README.md
@@ -1,0 +1,7 @@
+# Reference
+
+> Technical descriptions for lookup, not sequential reading.
+
+- [Architecture](developers/reference/architecture.md) — system components and how they connect
+- [Supabase Configuration](developers/reference/supabase-config.md) — database, API, and Realtime settings
+- [PowerSync Configuration](developers/reference/powersync-config.md) — sync rules, client setup, and JWKS

--- a/docs/developers/tutorials/README.md
+++ b/docs/developers/tutorials/README.md
@@ -1,0 +1,9 @@
+# Tutorials
+
+> End-to-end walkthroughs that build a working app from scratch.
+
+Each tutorial builds on the previous one, progressively adding capabilities. Work through them in order:
+
+1. [Build a Notes App with Supabase](developers/tutorials/online-first.md) — start with a basic online-first app that reads and writes directly to a cloud database
+2. [Add Realtime Sync](developers/tutorials/online-with-sync.md) — add WebSocket-based sync so multiple clients see changes instantly
+3. [Make It Work Offline](developers/tutorials/offline-first.md) — add a local SQLite database with PowerSync for full offline support

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,23 +30,138 @@
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     }
-    .sidebar .app-name {
-      font-size: 1.1rem;
-      font-weight: 700;
-      letter-spacing: -0.02em;
+
+    /* ── Site header ────────────────────────────── */
+    .site-header {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      z-index: 100;
+      background: #fff;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+      display: flex;
+      align-items: center;
+      height: 58px;
+      padding: 0 1.5em;
     }
-    .sidebar-nav > ul > li > a {
+    .site-header .home-btn {
+      display: flex;
+      align-items: center;
+      text-decoration: none;
+      color: var(--theme-color);
+      flex-shrink: 0;
+      margin-right: 0.6em;
+      transition: opacity 0.15s;
+    }
+    .site-header .home-btn:hover {
+      opacity: 0.7;
+    }
+    .site-header .home-btn svg {
+      width: 20px;
+      height: 20px;
+    }
+    .site-header .site-brand {
+      font-size: 1.3rem;
+      font-weight: 700;
+      color: #222;
+      letter-spacing: -0.02em;
+      white-space: nowrap;
+      text-decoration: none;
+    }
+    .site-header .site-brand:hover {
+      color: var(--theme-color);
+    }
+    .site-header .site-subtitle {
+      font-size: 0.88rem;
+      color: #555;
+      margin-left: 0.8em;
+      padding-left: 0.8em;
+      border-left: 1px solid #ddd;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      min-width: 0;
+    }
+    .site-header .role-tabs {
+      position: static;
+      display: flex;
+      gap: 0;
+      margin-left: auto;
+      height: 100%;
+      align-items: stretch;
+      flex-shrink: 0;
+    }
+    .site-header .role-tab {
+      display: flex;
+      align-items: center;
+      padding: 0 1em;
+      text-decoration: none;
+      font-size: 0.82rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: #888;
+      border-bottom: 2px solid transparent;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .site-header .role-tab:hover {
+      color: #444;
+    }
+    .site-header .role-tab.active {
+      color: var(--theme-color);
+      border-bottom-color: var(--theme-color);
+    }
+
+    /* Push everything below the header */
+    body {
+      padding-top: 58px;
+    }
+    .sidebar {
+      padding-top: 58px !important;
+    }
+
+    /* Hide Docsify's built-in app-name since we have the header */
+    .sidebar .app-name {
+      display: none;
+    }
+
+    /* ── Sidebar nav styling ───────────────────── */
+    /* Top-level links: roles (Developer, Maintainer, Contributor) + Home */
+    .sidebar-nav > ul > li.folder > a {
       font-weight: 600;
       text-transform: uppercase;
       font-size: 0.75rem;
       letter-spacing: 0.05em;
-      color: #999;
-      pointer-events: none;
+      color: #666;
+      cursor: pointer;
     }
+    .sidebar-nav > ul > li.folder > a:hover {
+      color: var(--theme-color);
+    }
+    /* Section-level links (Tutorials, How-To, etc.) */
     .sidebar-nav > ul > li > ul > li > a {
-      font-weight: 500;
+      font-weight: 600;
+      font-size: 0.82rem;
+      color: #555;
+    }
+    .sidebar-nav > ul > li > ul > li > a:hover {
+      color: var(--theme-color);
+    }
+    /* Leaf-level links (individual pages) */
+    .sidebar-nav > ul > li > ul > li > ul > li > a {
+      font-weight: 400;
       font-size: 0.85rem;
     }
+    /* Visual separation between role groups */
+    .sidebar-nav > ul > li.folder {
+      margin-top: 0.8em;
+    }
+    .sidebar-nav > ul > li.folder:first-of-type {
+      margin-top: 0;
+    }
+
+    /* ── Content styling ───────────────────────── */
     .markdown-section h1 + blockquote {
       border-left: 3px solid var(--theme-color);
       background: #f0fdf4;
@@ -68,6 +183,22 @@
   </style>
 </head>
 <body>
+  <!-- Site header with title, home button, and role tabs -->
+  <header class="site-header">
+    <a href="#/" class="home-btn" title="Home">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
+        <polyline points="9 22 9 12 15 12 15 22"/>
+      </svg>
+    </a>
+    <a href="#/" class="site-brand">Learn Offline-First Data Management and Synchronisation</a>
+    <nav class="role-tabs">
+      <a href="#/developers/" class="role-tab" data-role="developers">Developer</a>
+      <a href="#/maintainers/" class="role-tab" data-role="maintainers">Maintainer</a>
+      <a href="#/contributors/" class="role-tab" data-role="contributors">Contributor</a>
+    </nav>
+  </header>
+
   <div id="app"></div>
 
   <script>
@@ -76,7 +207,8 @@
       repo: 'https://github.com/virtualian/offline-first',
       loadSidebar: true,
       subMaxLevel: 2,
-      homepage: 'developers/explanation/online-first.md',
+      sidebarDisplayLevel: 1,
+      homepage: 'README.md',
       search: {
         placeholder: 'Search docs...',
         noData: 'No results.',
@@ -106,17 +238,28 @@
   <!-- Copy code -->
   <script src="https://cdn.jsdelivr.net/npm/docsify-copy-code@2/dist/docsify-copy-code.min.js"></script>
 
+  <!-- Sidebar collapse -->
+  <script src="https://cdn.jsdelivr.net/npm/docsify-sidebar-collapse/dist/docsify-sidebar-collapse.min.js"></script>
+
   <!-- Mermaid -->
   <script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
   <script>
     mermaid.initialize({ startOnLoad: false, theme: 'default' })
 
     // Re-render Mermaid diagrams after each page load
-    window.$docsify.plugins = [function (hook) {
+    // Highlight active role tab based on current URL
+    ;(window.$docsify.plugins = window.$docsify.plugins || []).push(function (hook) {
       hook.doneEach(function () {
         mermaid.run({ querySelector: '.mermaid' })
+
+        // Update role tab active state
+        var hash = location.hash || '#/'
+        document.querySelectorAll('.site-header .role-tab').forEach(function (tab) {
+          var role = tab.getAttribute('data-role')
+          tab.classList.toggle('active', hash.indexOf('#/' + role + '/') === 0)
+        })
       })
-    }]
+    })
   </script>
 
   <!-- Syntax highlighting -->

--- a/docs/maintainers/README.md
+++ b/docs/maintainers/README.md
@@ -1,0 +1,11 @@
+# Maintainer Docs
+
+> For anyone operating, deploying, or maintaining this project.
+
+These docs cover running the demos, infrastructure details, and the reasoning behind architectural decisions.
+
+## Sections
+
+- [How-To](maintainers/how-to/) — operational tasks like running all demos
+- [Reference](maintainers/reference/) — infrastructure and configuration details
+- [Explanation](maintainers/explanation/) — architecture decisions and trade-offs

--- a/docs/maintainers/explanation/README.md
+++ b/docs/maintainers/explanation/README.md
@@ -1,0 +1,5 @@
+# Explanation
+
+> Reasoning behind architectural and operational decisions.
+
+- [Architecture Decisions](maintainers/explanation/architecture-decisions.md) — why things are built this way

--- a/docs/maintainers/how-to/README.md
+++ b/docs/maintainers/how-to/README.md
@@ -1,0 +1,5 @@
+# How-To Guides
+
+> Operational tasks for project maintainers.
+
+- [Run All Demos](maintainers/how-to/run-demos.md) — start every demo in the correct order

--- a/docs/maintainers/reference/README.md
+++ b/docs/maintainers/reference/README.md
@@ -1,0 +1,5 @@
+# Reference
+
+> Infrastructure and configuration details.
+
+- [Infrastructure](maintainers/reference/infrastructure.md) — services, environments, and access


### PR DESCRIPTION
## Summary
- Restructure READMEs: clone + docs are now the first getting started steps, new title and highlight box with linked Supabase/PowerSync docs
- Add docs site header with title, home button, and role-based navigation tabs
- Add collapsible sidebar with intro pages for each role (Developer, Maintainer, Contributor) and content type (Tutorials, How-To, Reference, Explanation)
- Add docs landing page as getting-started guide replacing direct jump to explanation content
- Fix docsify-sidebar-collapse plugin: mermaid plugin overwrite and single-ul processing bugs
- Fix docsify-themeable `position: absolute` on nav elements breaking header tab layout
- Add KNOWN_ISSUES.md and RELEASE_NOTES.md with v3.2.0 pre-empted
- Add releases and discussions references to both READMEs
- Update documentation standard with release docs checklist

## Test plan
- [x] Serve docs locally (`python3 -m http.server 8080 --directory docs`) and verify landing page loads
- [x] Verify header: home icon navigates to `#/`, role tabs highlight correctly, brand text links home
- [x] Verify sidebar: roles and sections are collapsible, clicking navigates to intro pages
- [x] Verify KNOWN_ISSUES.md and RELEASE_NOTES.md render correctly on GitHub
- [x] Verify README releases table and links work on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)