### PR TITLE
Rename repo references to learn-offline-first-apps

### DIFF
--- a/.prd/.diataxis.md
+++ b/.prd/.diataxis.md
@@ -15,7 +15,7 @@ last_actioned: 2026-03-29
 
 ## Documentation Sources (Priority Order)
 
-1. **Primary:** https://github.com/virtualian/offline-first — repo documentation (9 docs), code (3 demo apps), README
+1. **Primary:** https://github.com/virtualian/learn-offline-first-apps — repo documentation (9 docs), code (3 demo apps), README
 2. **Code:** online-first-demo.html, online-sync-demo.html, powersync-demo/ — working demo source code
 
 ## Roles & Audiences

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -2,6 +2,20 @@
 
 > **Note:** Many issues in earlier releases (v1.0.0–v2.0.0) are deliberate simplifications to keep the implementation accessible for learning. They will be addressed progressively in later releases as complexity is layered in.
 
+## v3.3.0
+
+### Old release URLs contain previous repository name
+
+Release tags v1.0.0–v3.2.1 were created under the `offline-first` repository name. URLs in those tagged versions (README, docs) still reference `virtualian/offline-first`. GitHub redirects these automatically, but the redirect breaks if a new repository named `offline-first` is ever created under the same account.
+
+**Workaround:** None required — GitHub redirects work transparently. Avoid creating a new repo named `offline-first` under the `virtualian` account.
+
+### Existing clones require remote URL update
+
+Anyone who cloned the repository before the rename still has the old remote URL configured.
+
+**Fix:** Run `git remote set-url origin git@github.com:virtualian/learn-offline-first-apps.git`
+
 ## v3.2.1
 
 No new issues introduced. Documentation site responsive layout issue from v3.2.0 is resolved.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Built in small steps, starting from the simplest possible online-first baseline and progressively adding offline capabilities.
 
-**Questions or feedback?** Join the [discussions](https://github.com/virtualian/offline-first/discussions).
+**Questions or feedback?** Join the [discussions](https://github.com/virtualian/learn-offline-first-apps/discussions).
 
 ## What's Here
 
@@ -22,8 +22,8 @@ Built in small steps, starting from the simplest possible online-first baseline 
 ### 1. Clone the repo
 
 ```bash
-git clone https://github.com/virtualian/offline-first.git
-cd offline-first
+git clone https://github.com/virtualian/learn-offline-first-apps.git
+cd learn-offline-first-apps
 ```
 
 ### 2. Run the docs
@@ -131,17 +131,18 @@ Each release marks a working milestone in the progression from online-first to o
 
 | Release | What it adds |
 |---|---|
-| [v1.0.0](https://github.com/virtualian/offline-first/releases/tag/v1.0.0) | Initial online-first example app — direct reads and writes to Supabase |
-| [v2.0.0](https://github.com/virtualian/offline-first/releases/tag/v2.0.0) | Online sync with Supabase Realtime — multi-client WebSocket sync |
-| [v3.0.0](https://github.com/virtualian/offline-first/releases/tag/v3.0.0) | Offline-first with PowerSync — local SQLite with bidirectional sync |
-| [v3.1.0](https://github.com/virtualian/offline-first/releases/tag/v3.1.0) | Diataxis documentation site |
-| [v3.2.0](https://github.com/virtualian/offline-first/releases/tag/v3.2.0) | Improved docs site with header, collapsible sidebar, and release docs |
-| [v3.2.1](https://github.com/virtualian/offline-first/releases/tag/v3.2.1) | Responsive docs site — mobile and tablet layout fix |
+| [v1.0.0](https://github.com/virtualian/learn-offline-first-apps/releases/tag/v1.0.0) | Initial online-first example app — direct reads and writes to Supabase |
+| [v2.0.0](https://github.com/virtualian/learn-offline-first-apps/releases/tag/v2.0.0) | Online sync with Supabase Realtime — multi-client WebSocket sync |
+| [v3.0.0](https://github.com/virtualian/learn-offline-first-apps/releases/tag/v3.0.0) | Offline-first with PowerSync — local SQLite with bidirectional sync |
+| [v3.1.0](https://github.com/virtualian/learn-offline-first-apps/releases/tag/v3.1.0) | Diataxis documentation site |
+| [v3.2.0](https://github.com/virtualian/learn-offline-first-apps/releases/tag/v3.2.0) | Improved docs site with header, collapsible sidebar, and release docs |
+| [v3.2.1](https://github.com/virtualian/learn-offline-first-apps/releases/tag/v3.2.1) | Responsive docs site — mobile and tablet layout fix |
+| [v3.3.0](https://github.com/virtualian/learn-offline-first-apps/releases/tag/v3.3.0) | Repository renamed to `learn-offline-first-apps` |
 
-See all [releases](https://github.com/virtualian/offline-first/releases) | [release notes](RELEASE_NOTES.md) | [known issues](KNOWN_ISSUES.md).
+See all [releases](https://github.com/virtualian/learn-offline-first-apps/releases) | [release notes](RELEASE_NOTES.md) | [known issues](KNOWN_ISSUES.md).
 
 ---
 
 ## Discussions
 
-Questions, ideas, or feedback? Join the [discussions](https://github.com/virtualian/offline-first/discussions).
+Questions, ideas, or feedback? Join the [discussions](https://github.com/virtualian/learn-offline-first-apps/discussions).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## v3.3.0 — Repository Rename
+
+Released: 2026-03-29
+
+- Renamed repository from `offline-first` to `learn-offline-first-apps`
+- Updated all internal GitHub URLs, clone commands, and Docsify config
+- Old URLs redirect automatically via GitHub
+
 ## v3.2.1 — Responsive Docs Site
 
 Released: 2026-03-29

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,9 +4,9 @@
 
 This project starts from the simplest possible online-first baseline and progressively adds offline capabilities, one step at a time. Each step has a working demo and documentation explaining the concepts behind it.
 
-Each [release](https://github.com/virtualian/offline-first/releases) marks a working milestone — from online-first ([v1.0.0](https://github.com/virtualian/offline-first/releases/tag/v1.0.0)) through realtime sync ([v2.0.0](https://github.com/virtualian/offline-first/releases/tag/v2.0.0)) to offline-first ([v3.0.0](https://github.com/virtualian/offline-first/releases/tag/v3.0.0)). Check out any tag to see the project at that stage. See the [release notes](https://github.com/virtualian/offline-first/blob/main/RELEASE_NOTES.md) and [known issues](https://github.com/virtualian/offline-first/blob/main/KNOWN_ISSUES.md).
+Each [release](https://github.com/virtualian/learn-offline-first-apps/releases) marks a working milestone — from online-first ([v1.0.0](https://github.com/virtualian/learn-offline-first-apps/releases/tag/v1.0.0)) through realtime sync ([v2.0.0](https://github.com/virtualian/learn-offline-first-apps/releases/tag/v2.0.0)) to offline-first ([v3.0.0](https://github.com/virtualian/learn-offline-first-apps/releases/tag/v3.0.0)). Check out any tag to see the project at that stage. See the [release notes](https://github.com/virtualian/learn-offline-first-apps/blob/main/RELEASE_NOTES.md) and [known issues](https://github.com/virtualian/learn-offline-first-apps/blob/main/KNOWN_ISSUES.md).
 
-**Questions or feedback?** Join the [discussions](https://github.com/virtualian/offline-first/discussions).
+**Questions or feedback?** Join the [discussions](https://github.com/virtualian/learn-offline-first-apps/discussions).
 
 ## What you'll learn
 

--- a/docs/contributors/how-to/contributing.md
+++ b/docs/contributors/how-to/contributing.md
@@ -2,12 +2,12 @@
 
 ## Fork and Clone
 
-1. Fork the repository at [github.com/virtualian/offline-first](https://github.com/virtualian/offline-first).
+1. Fork the repository at [github.com/virtualian/learn-offline-first-apps](https://github.com/virtualian/learn-offline-first-apps).
 2. Clone your fork locally:
 
 ```bash
-git clone https://github.com/<your-username>/offline-first.git
-cd offline-first
+git clone https://github.com/<your-username>/learn-offline-first-apps.git
+cd learn-offline-first-apps
 ```
 
 ## Branch Naming
@@ -98,7 +98,7 @@ Keep PRs focused -- one concern per PR. If your change spans multiple topics, sp
 
 ## What to Work On
 
-Check [GitHub Issues](https://github.com/virtualian/offline-first/issues) for open items. Issues are labeled by type:
+Check [GitHub Issues](https://github.com/virtualian/learn-offline-first-apps/issues) for open items. Issues are labeled by type:
 
 | Label | Meaning |
 |:------|:--------|

--- a/docs/index.html
+++ b/docs/index.html
@@ -222,7 +222,7 @@
   <script>
     window.$docsify = {
       name: 'Offline-First',
-      repo: 'https://github.com/virtualian/offline-first',
+      repo: 'https://github.com/virtualian/learn-offline-first-apps',
       loadSidebar: true,
       subMaxLevel: 2,
       sidebarDisplayLevel: 1,


### PR DESCRIPTION
## Summary
- Update all GitHub URLs, clone commands, and Docsify config from `offline-first` to `learn-offline-first-apps` across 7 files
- Add v3.3.0 release notes and known issues documenting rename consequences
- Conceptual term "offline-first" left untouched throughout all prose

Closes #12

## Post-merge steps (manual)
- [ ] Rename GitHub repo: Settings → General → `learn-offline-first-apps`
- [ ] Rename local folder: `mv ~/projects/offline-first ~/projects/learn-offline-first-apps`
- [ ] Update git remote: `git remote set-url origin git@github.com:virtualian/learn-offline-first-apps.git`
- [ ] Tag and release v3.3.0

## Test plan
- [ ] Grep confirms zero live URLs referencing `virtualian/offline-first`
- [ ] All "offline-first" conceptual usage in prose unchanged
- [ ] Docsify `name: 'Offline-First'` display name preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)